### PR TITLE
fix build.rs

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -48,7 +48,7 @@ fn main() {
             .flag("-fdata-sections")
             .flag("-ffunction-sections")
             .flag("-flto")
-            .target("riscv32-unknown-none-elf");
+            .target("riscv32im-unknown-none-elf");
     }
 
     base_config.include("depend/secp256k1/")


### PR DESCRIPTION
A change to cc ( [see PR here](https://github.com/rust-lang/cc-rs/pull/1225) ) breaks the [secp build.rs](https://github.com/sp1-patches/rust-secp256k1/commit/13910d476dbdaf436312a9f096ee312593028557#diff-f6a268fbd49396f369a577d6a338ac3593efb91e635aff44699f6968c6d80f72R20-R29).

